### PR TITLE
Change check_is_callable to use std::invoke_result (when available)

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -155,12 +155,21 @@ namespace traits {
  * @brief function (class) signature type trait
  *
  *****************************************************************************/
+template <class Fn, class... Args>
+struct invoke_result {
+#if defined(__cpp_lib_is_invocable)
+    using type = std::invoke_result<Fn, Args...>::type; // First available in c++17.
+#else
+    using type = std::result_of<Fn(Args...)>::type; // Deprecated in c++17; removed in c++20.
+#endif
+};
+
 template<class Fn, class Ret, class... Args>
 constexpr auto
 check_is_callable(int) -> decltype(
     std::declval<Fn>()(std::declval<Args>()...),
     std::integral_constant<bool,
-        std::is_same<Ret,typename std::result_of<Fn(Args...)>::type>::value>{} );
+        std::is_same<Ret,typename invoke_result<Fn,Args...>::type>::value>{} );
 
 template<class,class,class...>
 constexpr auto
@@ -171,7 +180,7 @@ constexpr auto
 check_is_callable_without_arg(int) -> decltype(
     std::declval<Fn>()(),
     std::integral_constant<bool,
-        std::is_same<Ret,typename std::result_of<Fn()>::type>::value>{} );
+        std::is_same<Ret,typename invoke_result<Fn>::type>::value>{} );
 
 template<class,class>
 constexpr auto


### PR DESCRIPTION
This change fixes a `c++20` compilation error.

In `c++20`, `std::result_of` is no longer available, and `clipp` does not compile (at least for `msvc` with `/std:c++latest`).

To maintain compatibility with `c++11` and `c++14`, `clipp::traits::invoke_result` is added.
It uses `std::invoke_result` when available, and `std::result_of` otherwise.